### PR TITLE
fix: Allow for additional properties on root for camel-dashboard-openshift-all

### DIFF
--- a/helm/camel-monitor/values.schema.json
+++ b/helm/camel-monitor/values.schema.json
@@ -247,5 +247,5 @@
       "additionalProperties": false
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }


### PR DESCRIPTION
Failling with:
```
helm lint . --set hawtio-online-console-plugin.mockProxySecret=true
==> Linting .
[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
camel-monitor-operator:
- (root): Additional property enabled is not allowed
- (root): Additional property global is not allowed

```