### PR TITLE
ci: upgrade minikube action

### DIFF
--- a/.github/actions/infra-setting/action.yml
+++ b/.github/actions/infra-setting/action.yml
@@ -33,7 +33,7 @@ runs:
     uses: azure/setup-kubectl@v5
   - id: minikube-start
     name: Start minikube
-    uses: medyagh/setup-minikube@v0.0.18
+    uses: medyagh/setup-minikube@v0.0.21
     with:
       addons: registry
       cpus: max


### PR DESCRIPTION
We should avoid any version still on node 20 runner